### PR TITLE
Add dockerfile_lint for Dockerfile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ This project is not closed to actual static analyzers. With this repository we i
 
 ### Dockerfile
 
+- [dockerfile_lint](https://github.com/projectatomic/dockerfile_lint) - A rule based linter for Dockerfiles. The linter rules can be used to check file syntax as well as arbitrary semantic and best practice attributes determined by the rule file writer. The linter can also be used to check LABEL rules against docker images.
 - [hadolint](https://github.com/hadolint/hadolint)  - Linter for Dockerfiles. The linter is parsing the Dockerfile into an AST and performs rules on top of the AST. It is standing on the shoulders of ShellCheck to lint the Bash code inside RUN instructions.
 
 ### English


### PR DESCRIPTION
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**
- Language: Dockerfiles, written  in nodejs
- Linter: dockerfile_lint
- URL: https://github.com/projectatomic/dockerfile_lint
Pretty neat tool from Project Atomic http://www.projectatomic.io/docs/introduction/

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**
- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template:  "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).
<!-- Thank you for helping out! -->
