### PR TITLE
Add jinjalint for HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ This project is not closed to actual static analyzers. With this repository we i
 
 - [htmlhint](https://github.com/yaniswang/HTMLHint) - HTMLHint is a Static Code Analysis Tool for HTML, you can use it with IDE or in build system.
 - [bootlint](https://github.com/twbs/bootlint) - Bootlint is a tool that checks for several common HTML mistakes in webpages that are using Bootstrap.
+- [jinjalint](https://github.com/motet-a/jinjalint) - A prototype linter which checks the indentation and the correctness of Jinja-like/HTML templates. Also supports Django Templates.
 
 ### Java
 


### PR DESCRIPTION
jinjalint isn't strictly for HTML, but since bootlint is there as well it feels like the right place. I didn't add it in sort order, since the HTML section doesn't use that at the moment. Can make that change if needed.

<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**
- Language: HTML / Jinja2 templates / Django templates
- Linter: jinjalint
- URL: https://github.com/motet-a/jinjalint

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**
- [x] Only added one linter?
- [x] Is it inside the right language container?
- ~[ ] Is it sorted alphabetically inside the container?~ – No, that section isn't sorted alphabetically
- [x] Does the title follow the template:  "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).
<!-- Thank you for helping out! -->
