### PR TITLE
Add golangci-lint for Go.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ this topic will be welcome as well as links related to actual linters.
 ### Go
 
 - [golangci-lint](https://github.com/golangci/golangci-lint) - Linters Runner
-  for Go. 5x faster than gometalinter. Nice colored output. Can report only
-  new issues. Fewer false-positives. Yaml/toml config.
+  for Go. 5x faster than gometalinter. Nice colored output. Can report only new
+  issues. Fewer false-positives. Yaml/toml config.
 - [golint](https://github.com/golang/lint) - Go style linter written in Go.
   Focus with coding styles more than with correctness.
 - [gometalinter](https://github.com/alecthomas/gometalinter) - Concurrently run

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ this topic will be welcome as well as links related to actual linters.
 
 ### Go
 
+- [golangci-lint](https://github.com/golangci/golangci-lint) - Linters Runner
+  for Go. 5x faster than gometalinter. Nice colored output. Can report only
+  new issues. Fewer false-positives. Yaml/toml config.
 - [golint](https://github.com/golang/lint) - Go style linter written in Go.
   Focus with coding styles more than with correctness.
 - [gometalinter](https://github.com/alecthomas/gometalinter) - Concurrently run


### PR DESCRIPTION
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: Golang
- Linter: golangci-lint
- URL: https://github.com/golangci/golangci-lint

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [ Y ] Only added one linter?
- [ Y ] Is it inside the right language container?
- [ Y ] Is it sorted alphabetically inside the container?
- [ Y ] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
