### PR TITLE
fix: remove Git section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ this topic will be welcome as well as links related to actual linters.
   - [Elixir](#elixir)
   - [English](#english)
   - [Erlang](#erlang)
-  - [Git](#git)
   - [Go](#go)
   - [GraphQL](#graphql)
   - [Haskell](#haskell)


### PR DESCRIPTION
It previously contained commitlint, but it was later moved to Language Agnostic section.