### PR TITLE
Add wemake-python-styleguide for python

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ this topic will be welcome as well as links related to actual linters.
 - [pylint](https://github.com/PyCQA/pylint) - Source code analyzer which looks
   for programming errors, helps enforcing a coding standard and sniffs for some
   code smells.
+- [wemake-python-styleguide](https://github.com/wemake-services/wemake-python-styleguide) -
+  The strictest and most opinionated python linter ever.
 - [yala](https://github.com/cemsbr/yala) - YALA combines many linters to improve
   the quality of your code.
 


### PR DESCRIPTION
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: Python
- Linter: wemake-python-styleguide
- URL: https://github.com/wemake-services/wemake-python-styleguide

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?
