### PR TITLE
Update GitHub link to ameba linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ this topic will be welcome as well as links related to actual linters.
 
 ### Crystal
 
-- [ameba](https://github.com/veelenga/ameba) - Static code analysis tool for
+- [ameba](https://github.com/crystal-ameba/ameba) - Static code analysis tool for
   Crystal.
 
 ### CSS

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ this topic will be welcome as well as links related to actual linters.
 
 ### Crystal
 
-- [ameba](https://github.com/crystal-ameba/ameba) - Static code analysis tool for
-  Crystal.
+- [ameba](https://github.com/crystal-ameba/ameba) - Static code analysis tool
+  for Crystal.
 
 ### CSS
 


### PR DESCRIPTION
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: Crystal
- Linter: Ameba
- URL: https://github.com/crystal-ameba/ameba

The repo has been moved to its own org. Old lint is still valid.

