### PR TITLE
Add salt-lint for SaltStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ this topic will be welcome as well as links related to actual linters.
   - [reStructuredText](#restructuredtext)
   - [Ruby](#ruby)
   - [Rust](#rust)
+  - [SaltStack](#saltstack)
   - [Sass](#sass)
   - [Scala](#scala)
   - [Shell](#shell)
@@ -324,6 +325,11 @@ this topic will be welcome as well as links related to actual linters.
 
 - [rust-clippy](https://github.com/Manishearth/rust-clippy) - Collection of
   lints to catch common mistakes and improve your Rust code.
+
+### SaltStack
+
+- [salt-lint](https://github.com/warpnet/salt-lint) - A command-line utility
+  that checks for best practices in SaltStack.
 
 ### Sass
 


### PR DESCRIPTION
**Information:**

Add [salt-lint](https://github.com/warpnet/salt-lint) for [SaltStack](https://github.com/saltstack/salt).

- Language: [SaltStack](https://github.com/saltstack/salt) (_both SaltStack and salt-lint are written in Python_)
- Linter: [salt-lint](https://github.com/warpnet/salt-lint)
- URL: https://github.com/warpnet/salt-lint

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
