### PR TITLE
Add textlint for English

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ this topic will be welcome as well as links related to actual linters.
 - [proselint](https://github.com/amperser/proselint) - Linter for English that
   provides guidelines to make better writing. It has plugins for several editors
   and is configurable.
+- [textlint](https://textlint.github.io/) - The pluggable linting tool for
+  natural language texts.
 
 ### Erlang
 


### PR DESCRIPTION
Textlint has plugins for English and Japanese language, and maybe used for different file formats: Markdown, rst, AsciiDoc, LaTeX, HTML, etc.

<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: English / Japanese
- Linter: Textlint
- URL: https://textlint.github.io/

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
