### PR TITLE
Add dotenv-linter for env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ this topic will be welcome as well as links related to actual linters.
   - [Dockerfile](#dockerfile)
   - [Elixir](#elixir)
   - [English](#english)
+  - [Env](#env)
   - [Erlang](#erlang)
   - [Go](#go)
   - [GraphQL](#graphql)
@@ -162,6 +163,10 @@ this topic will be welcome as well as links related to actual linters.
   and is configurable.
 - [textlint](https://textlint.github.io/) - The pluggable linting tool for
   natural language texts.
+
+### Env
+
+- [dotenv-linter](https://github.com/mgrachev/dotenv-linter) - Linter for `.env` files.
 
 ### Erlang
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ this topic will be welcome as well as links related to actual linters.
 
 ### Env
 
-- [dotenv-linter](https://github.com/mgrachev/dotenv-linter) - Linter for `.env` files.
+- [dotenv-linter](https://github.com/mgrachev/dotenv-linter) - Linter for `.env`
+  files.
 
 ### Erlang
 


### PR DESCRIPTION
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: `.env` files
- Linter: dotenv-linter
- URL: https://github.com/mgrachev/dotenv-linter

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
