### PR TITLE
Add spectral for YAML.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,8 @@ this topic will be welcome as well as links related to actual linters.
 
 ### YAML
 
-- [spectral](https://github.com/stoplightio/spectral) - A flexible JSON/YAML linter, with out of the box support for OpenAPI v2/v3 and AsyncAPI v2.
+- [spectral](https://github.com/stoplightio/spectral) - A flexible JSON/YAML
+  linter, with out of the box support for OpenAPI v2/v3 and AsyncAPI v2.
 - [yamllint](https://github.com/adrienverge/yamllint) - Linter for YAML files.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ this topic will be welcome as well as links related to actual linters.
 
 ### YAML
 
+- [spectral](https://github.com/stoplightio/spectral) - A flexible JSON/YAML linter, with out of the box support for OpenAPI v2/v3 and AsyncAPI v2.
 - [yamllint](https://github.com/adrienverge/yamllint) - Linter for YAML files.
 
 ## Contributing


### PR DESCRIPTION
Maybe add `JSON` and `OpenAPI/AsyncAPI` sections, and add `spectral` to that three sections?

<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: YAML / JSON
- Linter: spectral
- URL: https://github.com/stoplightio/spectral

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
