### PR TITLE
Add Black for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ this topic will be welcome as well as links related to actual linters.
 
 ### Python
 
-- [black](https://github.com/psf/black) - The uncompromising Python code formatter. Blackened code looks the same regardless of the project you're reading.
+- [black](https://github.com/psf/black) - The uncompromising Python code
+  formatter. Blackened code looks the same regardless of the project you're
+  reading.
 - [flake8](https://github.com/PyCQA/flake8) - Runs PyFlakes, pycodestyle and
   other tools from only one CLI. Written in Python.
 - [pycodestyle (formerly called pep8)](https://github.com/PyCQA/pycodestyle) -

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ this topic will be welcome as well as links related to actual linters.
 
 ### Python
 
+- [black](https://github.com/psf/black) - The uncompromising Python code formatter. Blackened code looks the same regardless of the project you're reading.
 - [flake8](https://github.com/PyCQA/flake8) - Runs PyFlakes, pycodestyle and
   other tools from only one CLI. Written in Python.
 - [pycodestyle (formerly called pep8)](https://github.com/PyCQA/pycodestyle) -


### PR DESCRIPTION
**Information:**

- Language: Python
- Linter: Black
- URL: https://github.com/psf/black

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).
