### PR TITLE
Add LintHTML to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ this topic will be welcome as well as links related to actual linters.
 - [jinjalint](https://github.com/motet-a/jinjalint) - A prototype linter which
   checks the indentation and the correctness of Jinja-like/HTML templates. Also
   supports Django Templates.
+- [LintHTML](https://github.com/linthtml/linthtml) - LintHTML is a fork of htmllint. It is extendable via plugins.
 
 ### Java
 


### PR DESCRIPTION
It finally became awesome due to the possibility to extend the rules set via plugins. 🎉

**Information:**

- Language: HTML
- Linter: LintHTML
- URL: https://github.com/linthtml/linthtml

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).
