### PR TITLE
Add quick-lint-js for JavaScript.

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ this topic will be welcome as well as links related to actual linters.
   it can find, supports JS/TS/Flow and wrap ESLint (when `eslintrc` exists).
 - [standard](https://github.com/feross/standard) - JavaScript style linter that
   allows no configuration.
+- [quick-lint-js](https://quick-lint-js.com) - Finds bugs in JavaScript
+  programs. Designed for editors.
 - [xo](https://github.com/sindresorhus/xo) - Opinionated but configurable ESLint
   wrapper with lots of goodies included. Enforces strict and readable code.
 

--- a/README.md
+++ b/README.md
@@ -279,10 +279,10 @@ this topic will be welcome as well as links related to actual linters.
   ES2017, JSX, and Flow.
 - [putout](https://github.com/coderaiser/putout) - Linter that fixes everything
   it can find, supports JS/TS/Flow and wrap ESLint (when `eslintrc` exists).
-- [standard](https://github.com/feross/standard) - JavaScript style linter that
-  allows no configuration.
 - [quick-lint-js](https://quick-lint-js.com) - Finds bugs in JavaScript
   programs. Designed for editors.
+- [standard](https://github.com/feross/standard) - JavaScript style linter that
+  allows no configuration.
 - [xo](https://github.com/sindresorhus/xo) - Opinionated but configurable ESLint
   wrapper with lots of goodies included. Enforces strict and readable code.
 


### PR DESCRIPTION
**Information:**

- Language: JavaScript
- Linter: quick-lint-js
- URL: https://quick-lint-js.com/

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
