### PR TITLE
Add @coffelint.cli for CoffeeScript. Deprecated coffeelint

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,10 @@ this topic will be welcome as well as links related to actual linters.
 
 ### CoffeeScript
 
-- [coffeelint](https://github.com/clutchski/coffeelint) - Configurable linter
+- [@coffelint/cli](https://github.com/coffeelint/coffeelint) - Configurable linter
   written in CoffeScript to analyze CoffeScript.
+- [coffeelint](https://github.com/clutchski/coffeelint) - Deprecated predecessor
+  of `@coffelint/cli`.
 
 ### Crystal
 

--- a/README.md
+++ b/README.md
@@ -129,10 +129,8 @@ this topic will be welcome as well as links related to actual linters.
 
 ### CoffeeScript
 
-- [@coffelint/cli](https://github.com/coffeelint/coffeelint) - Configurable linter
-  written in CoffeScript to analyze CoffeScript.
-- [coffeelint](https://github.com/clutchski/coffeelint) - Deprecated predecessor
-  of `@coffelint/cli`.
+- [@coffelint/cli](https://github.com/coffeelint/coffeelint) - Configurable
+  linter written in CoffeScript to analyze CoffeScript.
 
 ### Crystal
 


### PR DESCRIPTION
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: CoffeeScript
- Linter: @coffeelint/cli
- URL: https://github.com/coffeelint/coffeelint

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
