### PR TITLE
Deleted `Mega-Linter` duplicate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,6 @@ this topic will be welcome as well as links related to actual linters.
 - [Mega-Linter](https://nvuillam.github.io/mega-linter) - Linters aggregator of
   37 languages, 12 formats, 15 tooling formats , copy-pastes and spell. Can
   automatically apply fixes with commit or Pull Request
-- [Mega-Linter](https://nvuillam.github.io/mega-linter) - Linters aggregator of
-  37 languages, 12 formats, 15 tooling formats , copy-pastes and spell. Can
-  automatically apply fixes with commit or Pull Request
 - [Scanmycode CE (Community Edition)](https://github.com/marcinguy/scanmycode-ce) -
   Code Scanning/SAST/Static Analysis/Linting using many tools/Scanners with One
   Report.


### PR DESCRIPTION
I'm new to git but i wanted to contribute, i am really sorry in the case i fuck anything up
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: language agnostic
- Linter: Mega-Linter
- URL: https://nvuillam.github.io/mega-linter

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [ ] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [ ] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
