### PR TITLE
Add ast-grep for Language Agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ this topic will be welcome as well as links related to actual linters.
 
 ### Language Agnostic
 
+- [ast-grep] (https://ast-grep.github.io/) - a fast and polyglot tool for code structural search, lint, rewriting at large scale.
 - [coala](https://github.com/coala-analyzer/coala) - Language agnostic linter
   based on rules and standards. Written in Python.
 - [commitlint](https://github.com/conventional-changelog/commitlint) -


### PR DESCRIPTION
Information:

Language: Agnostic
Linter: ast-grep
URL: - https://ast-grep.github.io
Checklist:

 - [x] Only added one linter?
 - [x] Is it inside the right language container?
 - [x] Is it sorted alphabetically inside the container?
 - [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?
For reference, there's some [contributing guidelines](https://github.com/CONTRIBUTING.md).