### PR TITLE
Add spectral for OpenAPI  (Swagger)

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,9 @@ this topic will be welcome as well as links related to actual linters.
 
 - [speccy](https://github.com/wework/speccy) - A handy toolkit for OpenAPI, with
   a linter to enforce quality rules.
+- [spectral](https://github.com/stoplightio/spectral) - A generic ruleset engine
+  on any JSON or YAML data, with built-in OpenAPI, AsyncAPI, and JSON Schema support
+  and support of custom rules.
 
 ### Perl
 


### PR DESCRIPTION
We use spectral to lint our Open API files
It allows us to integrate custom rules like making `cache-control` HTTP response header mandatory

**Information:**

- Language: Open API, Async API, JSON Schema
- Linter: Spectral
- URL: https://github.com/stoplightio/spectral

**Checklist:**

- [X] Only added one linter?
- [X] Is it inside the right language container?
- [X] Is it sorted alphabetically inside the container?
- [X] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?
