### PR TITLE
Add google/yamlfmt for YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ this topic will be welcome as well as links related to actual linters.
 
 - [spectral](https://github.com/stoplightio/spectral) - A flexible JSON/YAML
   linter, with out of the box support for OpenAPI v2/v3 and AsyncAPI v2.
+- [yamlfmt](https://github.com/google/yamlfmt) - Formatter for YAML files.
 - [yamllint](https://github.com/adrienverge/yamllint) - Linter for YAML files.
 
 ## Contributing


### PR DESCRIPTION
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: YAML
- Linter: yamlfmt
- URL: https://github.com/google/yamlfmt

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
