### PR TITLE
Add `blockwatch` for `Language Agnostic`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ this topic will be welcome as well as links related to actual linters.
 
 ### Language Agnostic
 
+- [blockwatch](https://github.com/mennanov/blockwatch) - Keeps your code and
+  documentation in sync and valid. Also available as a Github Action.
 - [coala](https://github.com/coala-analyzer/coala) - Language agnostic linter
   based on rules and standards. Written in Python.
 - [commitlint](https://github.com/conventional-changelog/commitlint) -


### PR DESCRIPTION
<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: agnostic
- Linter: blockwatch
- URL: https://github.com/mennanov/blockwatch

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [x] Is it sorted alphabetically inside the container?
- [x] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
