### PR TITLE
Add jfmt to list of code formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ this topic will be welcome as well as links related to actual linters.
   Velocity, XML, XSL.
 - [uncrustify](https://github.com/uncrustify/uncrustify) - Source code
   beautifier for C, C++, C#, ObjectiveC, D, Java, Pawn and VALA.
+- [jfmt](https://github.com/bmarwell/jfmt) - jfmt is an opinionated java source
+  code formatter for the command line  
 
 ### JavaScript
 


### PR DESCRIPTION
Add jfmt as a Java source code formatter.

<!-- Write anything you wish or feel is necessary above this comment. -->

**Information:**

- Language: Java
- Linter: jfmt
- URL: https://github.com/bmarwell/jfmt

<!-- Please tick all the boxes below if you fulfilled them. -->

**Checklist:**

- [x] Only added one linter?
- [x] Is it inside the right language container?
- [ ] Is it sorted alphabetically inside the container?
- [ ] Does the title follow the template: "Add [LINTER] for [LANGUAGE]."?

For reference, there's some [contributing guidelines](/CONTRIBUTING.md).

<!-- Thank you for helping out! -->
